### PR TITLE
Fix(i18n): extend regex to handle optional id prefix

### DIFF
--- a/lib/i18n/sync-utils.mjs
+++ b/lib/i18n/sync-utils.mjs
@@ -11,27 +11,27 @@ const { config } = JSON.parse(fs.readFileSync('package.json'))
  * Captures both formats: with app prefixes like "employer-branding-components-8WKgF6" and without like "ABC123"
  *
  * ^[-|+] // Matches start of line followed by either - or + (for git diff format)
- * 
+ *
  * .+? // Matches any characters (non-greedy) until next part
- * 
- * id[=|:] // Matches "id" followed by either = or :
- * 
+ *
+ * id[=:] // Matches "id" followed by either = or :
+ *
  * [^'|"]? // Optionally matches any single character that is not a quote
- * 
+ *
  * ['|"] // Matches either single or double quote
- * 
- * (?<id>...) // Named capturing group "id" containing:
- * 
- * (?:[\w-]+-)? // Optional non-capturing group for prefix: word chars or hyphens followed by hyphen
- * 
- * [\w-]{6} // Exactly 6 characters that can be word chars or hyphens
- * 
- * ['|"] // Closing quote (single or double)
- * 
+ *
+ * (?<id>(?:${config.i18n.app_name}-)? // Named capturing group "id" containing app name followed by hyphen
+ *
+ * \S{6} // Exactly 6 characters that can be word chars or hyphens
+ *
+ * ['"] // Closing quote (single or double)
+ *
  * /gm // Global and multiline flags
  */
-
-const regex = /^[-|+].+?id[=|:][^'|"]?['|"](?<id>(?:[\w-]+-)?[\w-]{6})['|"]/gm
+const regex = new RegExp(
+  `^[-+].+?id[=:][^'"]?['"](?<id>(?:${config.i18n.app_name}-)?\\S{6})['"]`,
+  'gm'
+)
 
 export const getNewToStaleIdMap = async () => {
   const excludeString = config.i18n.path_to_ignore ? `:^${config.i18n.path_to_ignore}` : ''

--- a/lib/i18n/sync-utils.mjs
+++ b/lib/i18n/sync-utils.mjs
@@ -7,6 +7,32 @@ const execute = promisify(exec)
 // get i18n config variables from package.json
 const { config } = JSON.parse(fs.readFileSync('package.json'))
 
+/**
+ * Captures both formats: with app prefixes like "employer-branding-components-8WKgF6" and without like "ABC123"
+ *
+ * ^[-|+] // Matches start of line followed by either - or + (for git diff format)
+ * 
+ * .+? // Matches any characters (non-greedy) until next part
+ * 
+ * id[=|:] // Matches "id" followed by either = or :
+ * 
+ * [^'|"]? // Optionally matches any single character that is not a quote
+ * 
+ * ['|"] // Matches either single or double quote
+ * 
+ * (?<id>...) // Named capturing group "id" containing:
+ * 
+ * (?:[\w-]+-)? // Optional non-capturing group for prefix: word chars or hyphens followed by hyphen
+ * 
+ * [\w-]{6} // Exactly 6 characters that can be word chars or hyphens
+ * 
+ * ['|"] // Closing quote (single or double)
+ * 
+ * /gm // Global and multiline flags
+ */
+
+const regex = /^[-|+].+?id[=|:][^'|"]?['|"](?<id>(?:[\w-]+-)?[\w-]{6})['|"]/gm
+
 export const getNewToStaleIdMap = async () => {
   const excludeString = config.i18n.path_to_ignore ? `:^${config.i18n.path_to_ignore}` : ''
   const { stderr: stagedDiffError, stdout: stagedDiff } = await execute(
@@ -27,7 +53,6 @@ export const getNewToStaleIdMap = async () => {
 
     for (let change of changes) {
       let { added, deleted } = change.groups
-      const regex = /^[-|+].+?id[=|:][^'|"]?['|"](?<id>\S{6})['|"]/gm
       const deletedChanges = deleted.matchAll(regex)
 
       // retrieve id.s from deleted lines

--- a/lib/i18n/sync-utils.test.mjs
+++ b/lib/i18n/sync-utils.test.mjs
@@ -1,0 +1,31 @@
+import { regex } from './sync-utils'
+
+describe('regex', () => {
+  it('should match IDs with prefixes', () => {
+    const line = '+  id="employer-branding-components-8WKgF6"'
+    const match = line.match(regex)
+    expect(match?.groups?.id).toBe('employer-branding-components-8WKgF6')
+  })
+
+  it('should match IDs without prefixes', () => {
+    const line = "-  id='XYZ789'"
+    const match = line.match(regex)
+    expect(match?.groups?.id).toBe('XYZ789')
+  })
+
+  it('should handle different id notations', () => {
+    const line1 = '+ id="GHI789"'
+    const match1 = line1.match(regex)
+    expect(match1?.groups?.id).toBe('GHI789')
+
+    const line2 = '+ id: "JKL012"'
+    const match2 = line2.match(regex)
+    expect(match2?.groups?.id).toBe('JKL012')
+  })
+
+  it('should not match lines without IDs', () => {
+    const line = '+  someOtherProperty="value"'
+    const match = line.match(regex)
+    expect(match).toBeNull()
+  })
+})


### PR DESCRIPTION
Libs like EBC uses an app prefix to avoid conflict in translations Ids 
- Adds an optional non-capturing group to catch any prefix